### PR TITLE
Replaced the slash in a wildcard with a dot

### DIFF
--- a/libs/robots.php
+++ b/libs/robots.php
@@ -94,7 +94,7 @@ class Robots {
             {
                 $rules[] = array(
                     'type' => $type,
-                    'match' => preg_quote(trim($rule[1]), '/')
+                    'match' => str_replace('\*', '.*',preg_quote(trim($rule[1]), '/'))
                 );
             }
         }


### PR DESCRIPTION
For a wildcard to work in preg_match the slash needs to be replaced with a dot.
